### PR TITLE
Add two new plugin types

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-rpc",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-rpc",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Remote procedure calls for ImJoy.",
   "module": "index.js",
   "scripts": {

--- a/javascript/src/base_frame.html
+++ b/javascript/src/base_frame.html
@@ -1,0 +1,5 @@
+<script
+  type="text/javascript"
+  onload="imjoyRPC.setupBaseFrame()"
+  src="/imjoy-rpc.min.js"
+></script>

--- a/javascript/src/main.js
+++ b/javascript/src/main.js
@@ -148,7 +148,9 @@ export function setupRPC(config) {
         config.type === "web-python-window"
       ) {
         setupWebPython(config);
-      } else if (config.type === "iframe" || config.type === "window") {
+      } else if (
+        ["rpc-window", "rpc-worker", "iframe", "window"].includes(config.type)
+      ) {
         setupIframe(config);
       } else {
         console.error("Unsupported plugin type: " + config.type);

--- a/javascript/webpack.config.js
+++ b/javascript/webpack.config.js
@@ -30,7 +30,8 @@ const config =  (env, argv) => ({
   },
   plugins: [
     new CopyPlugin([
-      { from: path.resolve(__dirname, 'src', 'jupyter-connection.js'), to: path.resolve(__dirname, 'dist', 'jupyter-connection.js')}
+      { from: path.resolve(__dirname, 'src', 'jupyter-connection.js'), to: path.resolve(__dirname, 'dist', 'jupyter-connection.js')},
+      { from: path.resolve(__dirname, 'src', 'base_frame.html'), to: path.resolve(__dirname, 'dist', 'base_frame.html')},
     ]),
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',


### PR DESCRIPTION
This PR adds two new plugin type `rpc-window` and `rpc-worker` for external plugins with or without GUI.