### PR TITLE
Fix close window bug

### DIFF
--- a/python/imjoy_rpc/connection/imjoy_colab.html
+++ b/python/imjoy_rpc/connection/imjoy_colab.html
@@ -239,9 +239,7 @@
         });
       });
       imjoy.event_bus.on("close_window", w => {
-        const idx = app.dialogWindows.indexOf(w)
-        if (idx >= 0)
-          app.dialogWindows.splice(idx, 1)
+        app.closeWindow(w)
         app.$forceUpdate()
       })
       imjoy.event_bus.on("add_window", w => {


### PR DESCRIPTION
This PR fixes the bug happened when using `api.close` or `windowObj.close` to close the window.