### PR TITLE
Set correct root directory for pip ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
   - package-ecosystem: pip
-    directory: "/"
+    directory: "/python"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10


### PR DESCRIPTION
- This should fix dependabot for PyPI packages.