### PR TITLE
Add release actions

### DIFF
--- a/.github/check-versions.sh
+++ b/.github/check-versions.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PYTHON_VERSION="$1"
+JS_VERSION="$2"
+
+if [ "$PYTHON_VERSION" = "$JS_VERSION" ]; then
+    echo "Versions are equal."
+    exit 0
+else
+    echo "Versions are not equal."
+    exit 1
+fi

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,68 @@
+autolabeler:
+  - label: "github_actions"
+    files:
+      - ".github/workflows/*"
+  - label: "ci"
+    files:
+      - ".github/*"
+  - label: "documentation"
+    files:
+      - "*.md"
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: "bug"
+    branch:
+      - '/fix\/.+/'
+    title:
+      - "/fix/i"
+  - label: "enhancement"
+    branch:
+      - '/feature\/.+/'
+    title:
+      - "/add/i"
+  - label: "refactoring"
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - "/refactor/i"
+  - label: "removal"
+    branch:
+      - '/remove\/.+/'
+    title:
+      - "/remove/i"
+  - label: "testing"
+    branch:
+      - '/test\/.+/'
+    title:
+      - "/test/i"
+categories:
+  - title: ":boom: Breaking Changes"
+    label: "breaking"
+  - title: ":rocket: Features"
+    label: "enhancement"
+  - title: ":fire: Removals and Deprecations"
+    label: "removal"
+  - title: ":beetle: Fixes"
+    label: "bug"
+  - title: ":racehorse: Performance"
+    label: "performance"
+  - title: ":rotating_light: Testing"
+    label: "testing"
+  - title: ":construction_worker: Continuous Integration"
+    labels:
+      - "ci"
+      - "github_actions"
+  - title: ":books: Documentation"
+    label: "documentation"
+  - title: ":hammer: Refactoring"
+    label: "refactoring"
+  - title: ":lipstick: Style"
+    label: "style"
+  - title: ":package: Dependencies"
+    labels:
+      - "dependencies"
+      - "build"
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -1,0 +1,27 @@
+name: Check versions
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: ~
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2.3.4
+      - name: Get Python version
+        id: python-version
+        run: |
+          echo "::set-output name=version::$(cat python/imjoy_rpc/VERSION | jq -r '.version')"
+      - name: Get Javascript version
+        id: js-version
+        run: |
+          echo "::set-output name=version::$(cat javascript/package.json | jq -r '.version')"
+      - name: Compare versions
+        run: |
+          .github/check-versions.sh "${{ steps.python-version.outputs.version }}" "${{ steps.js-version.outputs.version }}"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,15 @@
+name: Draft release
+
+on:
+  workflow_dispatch:
+  # pull_request event is required only for autolabeler
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5.15.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 2
       - name: Get Python version
         id: python-version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: "3.8"
+
+      - name: Upgrade pip
+        run: |
+          python -m pip install pip
+          pip --version
+
+      - name: Go to Python directory
+        run: |
+          cd python
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements_pypi.txt
+
+      - name: Check if there is a parent commit
+        id: check-parent-commit
+        run: |
+          echo "::set-output name=sha::$(git rev-parse --verify --quiet HEAD^)"
+
+      - name: Detect and tag new version
+        id: check-version
+        if: steps.check-parent-commit.outputs.sha
+        uses: salsify/action-detect-and-tag-new-version@v2.0.1
+        with:
+          version-command: |
+            bash -o pipefail -c "cat imjoy_rpc/VERSION | jq -r '.version'"
+
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package on PyPI
+        if: steps.check-version.outputs.tag
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: "${{ secrets.PYPI_TOKEN }}"
+
+      - name: Publish the release notes
+        uses: release-drafter/release-drafter@v5.15.0
+        with:
+          publish: "${{ steps.check-version.outputs.tag != '' }}"
+          tag: "${{ steps.check-version.outputs.tag }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,29 @@ on:
       - master
 
 jobs:
-  release:
-    name: Release
+  check:
+    name: Check versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
+      - name: Get Python version
+        id: python-version
+        run: |
+          echo "::set-output name=version::$(cat python/imjoy_rpc/VERSION | jq -r '.version')"
+      - name: Get Javascript version
+        id: js-version
+        run: |
+          echo "::set-output name=version::$(cat javascript/package.json | jq -r '.version')"
+      - name: Compare versions
+        run: |
+          .github/check-versions.sh "${{ steps.python-version.outputs.version }}" "${{ steps.js-version.outputs.version }}"
+
+  release-python:
+    name: Release Python
+    needs: check
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
@@ -23,7 +44,7 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          python -m pip install pip
+          python -m pip install --upgrade pip
           pip --version
 
       - name: Go to Python directory
@@ -32,7 +53,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          pip install tox tox-gh-actions
           pip install -r requirements_pypi.txt
+
+      - name: Test with tox
+        run: tox
 
       - name: Check if there is a parent commit
         id: check-parent-commit
@@ -65,3 +90,21 @@ jobs:
           tag: "${{ steps.check-version.outputs.tag }}"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  release-js:
+    name: Release Javascript
+    needs: release-python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 15.5.0
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run check-format
+      - run: npm run test
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/python/requirements_pypi.txt
+++ b/python/requirements_pypi.txt
@@ -1,0 +1,3 @@
+setuptools==56.0.0
+twine==3.4.1
+wheel==0.36.2


### PR DESCRIPTION
- check-versions will compare the python version in `python/imjoy_rpc/VERSION` and the javascript version in `javascript/package.json` and exit with 1 if they are not equal.
- release will also check versions before running the Python build and checking for a version bump. If a version bump is found, it will release to PyPI and then run the Javascript build and release to npm.
- release-drafter creates draft releases with auto-labeling of PRs and automatic headers taken from labels.