### PR TITLE
Reactivate npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,6 @@ jobs:
       - run: npm run build
       - name: Publish package on NPM
         if: steps.check-version.outputs.previous-version != steps.check-version.outputs.current-version
-        run: echo "We would publish to NPM now"
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- The release workflow works now. We can reactivate the NPM publish which was commented out.