### PR TITLE
Allow function.__name__ to be empty

### DIFF
--- a/python/imjoy_rpc/rpc.py
+++ b/python/imjoy_rpc/rpc.py
@@ -565,7 +565,7 @@ class RPC(MessageEmitter):
                     "_rtype": "callback",
                     # Some functions do not have the __name__ attribute
                     # for example when we use functools.partial to create functions
-                    "_rname": a_object.__name__ if hasattr(a_object, '__name__') else cid,
+                    "_rname": getattr(a_object, "__name__", cid),
                     "_rtarget_id": self._connection.peer_id,
                     "_rvalue": cid,
                 }

--- a/python/imjoy_rpc/rpc.py
+++ b/python/imjoy_rpc/rpc.py
@@ -563,7 +563,9 @@ class RPC(MessageEmitter):
                 cid = self._store.put(a_object)
                 b_object = {
                     "_rtype": "callback",
-                    "_rname": a_object.__name__,
+                    # Some functions do not have the __name__ attribute
+                    # for example when we use functools.partial to create functions
+                    "_rname": a_object.__name__ if hasattr(a_object, '__name__') else cid,
                     "_rtarget_id": self._connection.peer_id,
                     "_rvalue": cid,
                 }


### PR DESCRIPTION
In Python, if we use `functools.partial` the generated function doesn't contain a `__name__` attribute, so we should make it optional.